### PR TITLE
Fixed - Text overflowing in top contributors

### DIFF
--- a/src/components/styles/TeamCard.css
+++ b/src/components/styles/TeamCard.css
@@ -11,6 +11,7 @@
     width: 150px;
     cursor: pointer;
     height: 200px;
+    word-break: break-word;
 }
 .teamCard:hover img{
 transform: scale(1.05);


### PR DESCRIPTION
Added `word-wrap: break-word` property to Team card

![image](https://user-images.githubusercontent.com/78746713/136647806-18e9c4a8-1693-4c5b-b8c8-4969cd455fc1.png)
